### PR TITLE
Migrate admonition titles to bracket syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Increase your conversion rate by letting your customers pay with a fast, secure 
 
 You can also do important back office tasks such as capture and refund directly from Shopify. Easy for your customer and easy for you.
 
-:::tip Configure your online payment solution
+:::tip[Configure your online payment solution]
 This plugin can be used to configure either:
 
 - **Online payments** - Accept Vipps/MobilePay payments on your existing checkout flow


### PR DESCRIPTION
## Summary

Migrate admonition titles from the old `:::type Title` syntax to the preferred `:::type[Title]` bracket syntax, ahead of the Docusaurus v4 migration.

## Test plan

- [ ] Verify admonitions render correctly with titled headings
