### PR TITLE
Fix grammar in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To add branding and order information, install the [Companion app](companion.md)
 
 ## Payment
 
-When you enable this plugin, your customers will be able to choose Vipps or MobilePay as a payment method directly in the checkout. There is no need to go via a third party payment method. If your customer chooses Vipps or MobilePay, the customer fills in the contact information and is then asked to enter the phone number in the Vipps/MobilePay app. Then the customer confirms the payment in the Vipps/MobilePay app. The order is now completed and are now stored in your Shopify store.
+When you enable this plugin, your customers will be able to choose Vipps or MobilePay as a payment method directly in the checkout. There is no need to go via a third party payment method. If your customer chooses Vipps or MobilePay, the customer fills in the contact information and is then asked to enter the phone number in the Vipps/MobilePay app. Then the customer confirms the payment in the Vipps/MobilePay app. The order is now completed and is now stored in your Shopify store.
 
 **Please note:** We don't have a solution for *Express* in Shopify.
 This is due to limitations on Shopify's side, and if Shopify makes changes that

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To add branding and order information, install the [Companion app](companion.md)
 
 ## Payment
 
-When you enable this plugin, your customers will be able to choose Vipps or MobilePay as a payment method directly in the checkout. There is no need to go via a third party payment method. If your customer chooses Vipps or MobilePay, the customer fills in the contact information and is then asked to enter the phone number in the Vipps/MobilePay app. Then the customer confirms the payment in the Vipps/MobilePay app. The order is now completed and is now stored in your Shopify store.
+When you enable this plugin, your customers will be able to choose Vipps or MobilePay as a payment method directly in the checkout. There is no need to go via a third party payment method. If your customer chooses Vipps or MobilePay, they fill in the contact information and are asked to enter the phone number in the Vipps/MobilePay app. Then, they confirm the payment in the Vipps/MobilePay app. The order is now completed and is stored in your Shopify store.
 
 **Please note:** We don't have a solution for *Express* in Shopify.
 This is due to limitations on Shopify's side, and if Shopify makes changes that

--- a/shopify-faq.md
+++ b/shopify-faq.md
@@ -38,7 +38,7 @@ This also lets you add more payment information into the app.
 <div>
 END_HIDDEN_IN_GITHUB -->
 
-Alternatively, to add the Vipps or MobilePay logo in the footer, you'll can the theme files by adding/editing a line of code in your footer or where you'll want the logos to appear. An example would be, but needs testing in your shop before using:
+Alternatively, to add the Vipps or MobilePay logo in the footer, you can edit the theme files by adding/editing a line of code in your footer or where you'll want the logos to appear. An example would be, but needs testing in your shop before using:
 
 ```liquid
 {% assign enabled_payment_types = 'vipps,payment_2,payment_3' | remove: ' ' | split: ',' %}
@@ -127,7 +127,7 @@ When an order gets the "refunded" status, you have successfully refunded the ord
 
 #### Cancelled
 
-Orders with the "Cancelled" state we cancelled before being captured. Orders that are not captured yet, will be cancelled if you choose to cancel them in Shopify Admin. If the order is captured (hence in "Paid" state), it will be refunded instead.
+Orders with the "Cancelled" state were cancelled before being captured. Orders that are not captured yet, will be cancelled if you choose to cancel them in Shopify Admin. If the order is captured (hence in "Paid" state), it will be refunded instead.
 
 ### Fulfillment status
 


### PR DESCRIPTION
Conservative grammar fixes in README.md and shopify-faq.md: subject-verb agreement ('are' to 'is'), broken phrasing ('you''ll can' to 'you can edit'), and wrong verb form ('we cancelled' to 'were cancelled').